### PR TITLE
Update reference to use latest parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.ow2.authzforce</groupId>
 		<artifactId>authzforce-ce-parent</artifactId>
-		<version>8.0.3</version>
+		<version>8.0.4</version>
 	</parent>
 	<artifactId>authzforce-ce-xacml-json-model</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
Use latest version to get CVE fix for Spring framework once authzforce/parent#2 is merged.