### PR TITLE
Update parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.ow2.authzforce</groupId>
 		<artifactId>authzforce-ce-parent</artifactId>
-		<version>8.0.4</version>
+		<version>8.2.1</version>
 	</parent>
 	<artifactId>authzforce-ce-xacml-json-model</artifactId>
 	<packaging>jar</packaging>


### PR DESCRIPTION
Update to latest version of parent pom to benefit from newer version of Spring core that fix security vulnerability that currently prevent a successful build.