### PR TITLE
Update parent pom and org.everit.json.schema dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.ow2.authzforce</groupId>
 		<artifactId>authzforce-ce-parent</artifactId>
-		<version>8.2.1</version>
+		<version>8.3.0</version>
 	</parent>
 	<artifactId>authzforce-ce-xacml-json-model</artifactId>
 	<packaging>jar</packaging>
@@ -32,8 +32,8 @@
 			<artifactId>spring-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.github.everit-org.json-schema</groupId>
-			<artifactId>org.everit.json.schema</artifactId>
+			<groupId>com.github.erosb</groupId>
+			<artifactId>everit-json-schema</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.testng</groupId>


### PR DESCRIPTION
- Use parent version 8.3.0 to avoid build issue due to CVE in dependency.
- Dependency org.everit.json.schema renamed everit-json-schema.